### PR TITLE
pin werkzeug version, as safe_str_cmp was removed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask-cors==3.0.10
 python-dotenv==0.19.2
 pyOpenSSL==22.0.0
 Flask-Login==0.5.0
+Werkzeug==2.0.3


### PR DESCRIPTION
see https://stackoverflow.com/questions/71652965/importerror-cannot-import-name-safe-str-cmp-from-werkzeug-security